### PR TITLE
euroscipy-25: fix hyperlink

### DIFF
--- a/euroscipy-25-array-api/index.qmd
+++ b/euroscipy-25-array-api/index.qmd
@@ -123,7 +123,7 @@ slug: euroscipy-25-array-api
 
 - 'The Consortium for
 Python Data API Standards'
-- [https://data-apis.org]()
+- [https://data-apis.org](https://data-apis.org)
 - cross-ecosystem consortium
 - has been working on this for 5 years now
 


### PR DESCRIPTION
closes gh-2